### PR TITLE
cargo-hf2: Update deprecated hidapi usage

### DIFF
--- a/cargo-hf2/Cargo.toml
+++ b/cargo-hf2/Cargo.toml
@@ -15,7 +15,7 @@ readme = "readme.md"
 structopt = "0.3.2"
 colored = "1.8.0"
 hf2 = { version = "0.1.1", path="../hf2" }
-hidapi = "1.1.0"
+hidapi = "1.2.1"
 goblin = "0.0.24"
 hexdump = "0.1.0"
 cargo-project = "0.2.2"

--- a/cargo-hf2/src/main.rs
+++ b/cargo-hf2/src/main.rs
@@ -109,9 +109,9 @@ fn main() {
             0x1209 => vec![0x4D44, 0x2017],
         };
 
-        for device_info in api.devices() {
-            if let Some(products) = vendor.get(&device_info.vendor_id) {
-                if products.contains(&device_info.product_id) {
+        for device_info in api.device_list() {
+            if let Some(products) = vendor.get(&device_info.vendor_id()) {
+                if products.contains(&device_info.product_id()) {
                     if let Ok(d) = device_info.open_device(&api) {
                         device = Some(d);
                         break;

--- a/hf2-cli/Cargo.toml
+++ b/hf2-cli/Cargo.toml
@@ -14,7 +14,7 @@ readme = "readme.md"
 [dependencies]
 structopt = "0.3.2"
 hf2 = { version = "0.1.1", path="../hf2" }
-hidapi = "1.1.0"
+hidapi = "1.2.1"
 pretty_env_logger = "0.3.0"
 maplit = "1.0.2"
 crc-any = {version = "2.2.3", default-features = false }

--- a/hf2-cli/src/main.rs
+++ b/hf2-cli/src/main.rs
@@ -34,9 +34,9 @@ fn main() {
             0x1209 => vec![0x4D44, 0x2017],
         };
 
-        for device_info in api.devices() {
-            if let Some(products) = vendor.get(&device_info.vendor_id) {
-                if products.contains(&device_info.product_id) {
+        for device_info in api.device_list() {
+            if let Some(products) = vendor.get(&device_info.vendor_id()) {
+                if products.contains(&device_info.product_id()) {
                     if let Ok(d) = device_info.open_device(&api) {
                         device = Some(d);
                         break;


### PR DESCRIPTION
Tested by flashing Seeeduino XIAO (with the other open PR I have patched on top), which worked.