### PR TITLE
send entire program on flash ingoring device contents

### DIFF
--- a/cargo-hf2/src/main.rs
+++ b/cargo-hf2/src/main.rs
@@ -124,10 +124,15 @@ fn main() {
 
     println!("    {} {:?}", "Flashing".green().bold(), path);
 
+    let (binary, address) = elf_to_bin(path);
+
     // Start timer.
     let instant = Instant::now();
 
-    flash_elf(path, &d);
+    let bininfo = hf2::bin_info(&d).expect("bin_info failed");
+    log::debug!("{:?}", bininfo);
+
+    flash_bin(&binary, address, &bininfo, &d);
 
     // Stop timer.
     let elapsed = instant.elapsed();
@@ -151,63 +156,53 @@ fn exit_with_process_status(status: std::process::ExitStatus) -> ! {
     std::process::exit(status)
 }
 
-pub trait MemoryRange {
-    fn contains_range(&self, range: &std::ops::Range<u32>) -> bool;
-    fn intersects_range(&self, range: &std::ops::Range<u32>) -> bool;
-}
-
-impl MemoryRange for core::ops::Range<u32> {
-    fn contains_range(&self, range: &std::ops::Range<u32>) -> bool {
-        self.contains(&range.start) && self.contains(&(range.end - 1))
-    }
-
-    fn intersects_range(&self, range: &std::ops::Range<u32>) -> bool {
-        self.contains(&range.start) && !self.contains(&(range.end - 1))
-            || !self.contains(&range.start) && self.contains(&(range.end - 1))
-    }
-}
-
-/// Starts the download of a elf file.
-fn flash_elf(path: PathBuf, d: &HidDevice) {
+/// Returns a contiguous bin with 0s between non-contiguous sections and starting address from an elf.
+fn elf_to_bin(path: PathBuf) -> (Vec<u8>, u32) {
     let mut file = File::open(path).unwrap();
     let mut buffer = vec![];
     file.read_to_end(&mut buffer).unwrap();
 
-    if let Ok(binary) = goblin::elf::Elf::parse(&buffer.as_slice()) {
-        let bininfo = hf2::bin_info(&d).expect("bin_info failed");
+    let binary = goblin::elf::Elf::parse(&buffer.as_slice()).expect("Couldn't parse elf");
 
-        log::debug!("{:?}", bininfo);
+    // we need to fill any noncontigous section space with zeros to send over to uf2 bootloader in one batch (for some reason)
+    // todo this is a mess
+    let (data, _, start_address) = binary
+        .program_headers
+        .iter()
+        .filter(|ph| ph.p_type == PT_LOAD && ph.p_filesz > 0)
+        .fold(
+            (vec![], 0x0, 0x0),
+            move |(mut data, last_address, start_address), ph| {
+                log::debug!("{:?}", ph);
 
-        if bininfo.mode != hf2::BinInfoMode::Bootloader {
-            let _ = hf2::start_flash(&d).expect("start_flash failed");
-        }
+                let current_address = ph.p_filesz + ph.p_paddr;
 
-        //todo this could send multiple binary sections..
-        let flashed: u8 = binary
-            .program_headers
-            .iter()
-            .filter(|ph| ph.p_type == PT_LOAD && ph.p_filesz > 0)
-            .map(move |ph| {
-                log::debug!(
-                    "Flashing {:?} bytes @{:02X?}",
-                    ph.p_filesz as usize,
-                    ph.p_offset as usize,
-                );
+                //first time through we dont want any of the padding zeros and we want to set the starting address
+                if data.is_empty() {
+                    data.extend_from_slice(&buffer[ph.p_offset as usize..][..ph.p_filesz as usize]);
 
-                let data = &buffer[(ph.p_offset as usize)..][..ph.p_filesz as usize];
-                flash(data, ph.p_paddr as u32, &bininfo, &d);
-                1
-            })
-            .sum();
+                    (data, current_address, ph.p_paddr)
+                }
+                //other times through pad any space between sections and maintain the starting address
+                else {
+                    for _ in 0..(current_address - last_address) {
+                        data.push(0x0);
+                    }
 
-        //only reset if we actually sent something
-        if flashed > 0 {
-            let _ = hf2::reset_into_app(&d).expect("reset_into_app failed");
-        }
-    }
+                    data.extend_from_slice(&buffer[ph.p_offset as usize..][..ph.p_filesz as usize]);
+
+                    (data, current_address, start_address)
+                }
+            },
+        );
+
+    (data, start_address as u32)
 }
 
-fn flash(binary: &[u8], address: u32, bininfo: &hf2::BinInfoResponse, d: &HidDevice) {
+/// Flash, Verify and restart into app.
+fn flash_bin(binary: &[u8], address: u32, bininfo: &hf2::BinInfoResponse, d: &HidDevice) {
+    assert!(!binary.is_empty(), "Elf has nothing to flash?");
+
     let mut binary = binary.to_owned();
 
     //pad zeros to page size
@@ -218,13 +213,32 @@ fn flash(binary: &[u8], address: u32, bininfo: &hf2::BinInfoResponse, d: &HidDev
         binary.len(),
         padded_size
     );
-
     for _i in 0..(padded_size as usize - binary.len()) {
         binary.push(0x0);
     }
 
+    if bininfo.mode != hf2::BinInfoMode::Bootloader {
+        let _ = hf2::start_flash(&d).expect("start_flash failed");
+    }
+    flash(&binary, address, &bininfo, &d);
+    verify(&binary, address, &bininfo, &d);
+    let _ = hf2::reset_into_app(&d).expect("reset_into_app failed");
+}
+
+/// Flashes binary writing a single page at a time.
+fn flash(binary: &[u8], address: u32, bininfo: &hf2::BinInfoResponse, d: &HidDevice) {
+    for (page_index, page) in binary.chunks(bininfo.flash_page_size as usize).enumerate() {
+        let target_address = address + bininfo.flash_page_size * page_index as u32;
+
+        let _ = hf2::write_flash_page(&d, target_address, page.to_vec())
+            .expect("write_flash_page failed");
+    }
+}
+
+/// Verifys checksum of binary.
+fn verify(binary: &[u8], address: u32, bininfo: &hf2::BinInfoResponse, d: &HidDevice) {
     // get checksums of existing pages
-    let top_address = address + padded_size as u32;
+    let top_address = address + binary.len() as u32;
     let max_pages = bininfo.max_message_size / 2 - 2;
     let steps = max_pages * bininfo.flash_page_size;
     let mut device_checksums = vec![];
@@ -241,29 +255,22 @@ fn flash(binary: &[u8], address: u32, bininfo: &hf2::BinInfoResponse, d: &HidDev
             hf2::checksum_pages(&d, target_address, num_pages).expect("checksum_pages failed");
         device_checksums.extend_from_slice(&chk.checksums[..]);
     }
-    log::debug!("checksums received {:04X?}", device_checksums);
 
-    // only write changed contents
-    for (page_index, page) in binary.chunks(bininfo.flash_page_size as usize).enumerate() {
+    let mut binary_checksums = vec![];
+
+    //collect and sums so we can view all mismatches, not just first
+    for page in binary.chunks(bininfo.flash_page_size as usize) {
         let mut xmodem = CRCu16::crc16xmodem();
-
         xmodem.digest(&page);
 
-        if xmodem.get_crc() != device_checksums[page_index] {
-            log::debug!(
-                "ours {:04X?} != {:04X?} theirs, updating page {}",
-                xmodem.get_crc(),
-                device_checksums[page_index],
-                page_index,
-            );
-
-            let target_address = address + bininfo.flash_page_size * page_index as u32;
-            let _ = hf2::write_flash_page(&d, target_address, page.to_vec())
-                .expect("write_flash_page failed");
-        } else {
-            log::debug!("not updating page {}", page_index,);
-        }
+        binary_checksums.push(xmodem.get_crc());
     }
+
+    //only check as many as our binary has
+    assert_eq!(
+        &binary_checksums[..binary_checksums.len()],
+        &device_checksums[..binary_checksums.len()]
+    );
 }
 
 fn parse_hex_16(input: &str) -> Result<u16, std::num::ParseIntError> {


### PR DESCRIPTION
Closes #22 

huge thanks to @fionawhim for debugging this 

"The samd51 code Adafruit has is ok with random access writing, but it still assumes that you will send the complete program. It just doesn't care the order that it's sent"
https://github.com/adafruit/uf2-samdx1/blob/master/src/flash_samd51.c#L64

I dont think thats to spec, but meh, dont skip writing any pages even if their checksum is already present