### PR TITLE
add basic build, test, clippy, and rustfmt CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,49 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build - All Features
+      run: cargo build --verbose --all-features
+    - name: Build - Default
+      run: cargo build --verbose
+    - name: Build - Check Examples & Tests
+      run: cargo test --all-features
+
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          components: clippy
+          override: true
+    - uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all-features
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            components: rustfmt
+            override: true
+      - run: rustfmt --check --edition 2018 ./src/* ./examples/*

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-          toolchain: nightly
+          toolchain: stable
           components: clippy
           override: true
     - uses: actions-rs/clippy-check@v1
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             components: rustfmt
             override: true
       # rustfmt formats the project as a whole, so including only the entry points of each crate is sufficient

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: install libusb
+      run: sudo apt-get install libusb-1.0-0-dev
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
@@ -42,6 +44,8 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
+      - name: install libusb
+        run: sudo apt-get install libusb-1.0-0-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    -name: install libusb
+      run: sudo apt-get install libusb-1.0-0-dev
     - uses: actions/checkout@v2
     - name: Build - All Features
       run: cargo build --verbose --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    -name: install libusb
+    - name: install libusb
       run: sudo apt-get install libusb-1.0-0-dev
     - uses: actions/checkout@v2
     - name: Build - All Features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,4 +52,4 @@ jobs:
             toolchain: nightly
             components: rustfmt
             override: true
-      - run: rustfmt --check --edition 2018 ./src/* ./examples/*
+      - run: rustfmt --check --edition 2018 ./*

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,4 +52,5 @@ jobs:
             toolchain: nightly
             components: rustfmt
             override: true
-      - run: rustfmt --check --edition 2018 ./*
+      # rustfmt formats the project as a whole, so including only the entry points of each crate is sufficient
+      - run: rustfmt --check --edition 2018 ./cargo-hf2/src/main.rs ./hf2/src/lib.rs ./hf2-cli/src/main.rs


### PR DESCRIPTION
adds some basic GitHub actions CI for this repo. I saw #29 and thought I could pull in some actions CI that has worked well for me in other repos. To see what actions will trigger, see [this example PR on my fork](https://github.com/TDHolmes/hf2-rs/pull/3). It is currently failing looks like due to missing `libusb-1.0`. I'll try to fix that.

- [x] fix libusb failure