### PR TITLE
Make it possible to use in termux environment

### DIFF
--- a/cargo-hf2/Cargo.toml
+++ b/cargo-hf2/Cargo.toml
@@ -14,7 +14,7 @@ readme = "readme.md"
 structopt = "0.3.2"
 colored = "2.0.0"
 hf2 = { version = "^0.3.0", path = "../hf2" }
-hidapi = "1.2.1"
+hidapi = "1.4.0"
 cargo-project = "0.2.4"
 pretty_env_logger = "0.3.0"
 maplit = "1.0.2"

--- a/cargo-hf2/src/main.rs
+++ b/cargo-hf2/src/main.rs
@@ -173,4 +173,6 @@ struct Opt {
     pid: Option<u16>,
     #[structopt(name = "vid", long = "vid",  parse(try_from_str = parse_hex_16))]
     vid: Option<u16>,
+    #[structopt(short = "Z")]
+    unstable_features: Option<Vec<String>>
 }

--- a/cargo-hf2/src/main.rs
+++ b/cargo-hf2/src/main.rs
@@ -1,6 +1,7 @@
 use colored::*;
 use hf2::utils::{elf_to_bin, flash_bin, vendor_map};
 use hidapi::{HidApi, HidDevice};
+use std::env;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::Instant;
@@ -70,12 +71,16 @@ fn main() {
         exit_with_process_status(status)
     }
 
-    let api = HidApi::new().expect("Couldn't find system usb");
-
     let d = if let (Some(v), Some(p)) = (opt.vid, opt.pid) {
+        let api = HidApi::new().expect("Couldn't find system usb");
         api.open(v, p)
             .expect("Are you sure device is plugged in and in bootloader mode?")
+    } else if let Ok(v) = env::var("TERMUX_USB_FD") {
+        let api = HidApi::new_without_enumerate().expect("Couldn't find system usb");
+        let fd = v.parse().expect("TERMUX_USB_FD must be valid number");
+        api.wrap_sys_device(fd, -1).expect("Use with termux-usb")
     } else {
+        let api = HidApi::new().expect("Couldn't find system usb");
         println!(
             "    {} for a connected device with known vid/pid pair.",
             "Searching".green().bold(),


### PR DESCRIPTION
In the non-root Android platform (termux), these changes is necessary. 
it is only allowed to open usb devices with "libusb_wrap_sys_device" in such env.

Use with termux-usb helper.
``` 
termux-usb -E -e "cargo hf2" <device path>
```